### PR TITLE
Setting proper current directory for an executable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> anyhow::Result<()> {
     let mut hdc_cmd = Command::new("hdc");
     hdc_cmd
         .arg("shell")
-        .args(["cd", TEST_BIN_DIR, ";"].iter())
+        .args(["cd", TEST_BIN_DIR, "&&"].iter())
         .arg(on_device_bin_path)
         .args(remaining_args)
         .args([";", "echo", "$?", ">", &exit_code_file].iter());


### PR DESCRIPTION
Currently an executable is started from shell default directory. To use relative paths either the executable should change it's current directory itself or the test runner could set the current directory to the path of the executable. The second option looks more user friendly and should not change behaviour of existing executables since they could not reliably use relative paths.
